### PR TITLE
chore: bump Flask to >=3.1.3 (fix session Vary: Cookie, CVE-2026-27205)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.10,<4"
 readme = "README.md"
 license = "Apache-2.0"
 dependencies = [
-    "Flask>=2.3.2,<3",
+    "Flask>=3.1.3,<4",
     "flask-caching>=2.0.2,<3",
     "web3>=6.8.0,<7",
     # WSGI server invoked by the Dockerfile CMD; production runtime dep,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 license = "Apache-2.0"
 dependencies = [
     "Flask>=3.1.3,<4",
-    "flask-caching>=2.0.2,<3",
+    "flask-caching>=2.1.0,<3",
     "web3>=7.15.0,<8",
     # WSGI server invoked by the Dockerfile CMD; production runtime dep,
     # not a dev tool (was misclassified under Poetry's dev group).

--- a/uv.lock
+++ b/uv.lock
@@ -1425,7 +1425,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "flask", specifier = ">=3.1.3,<4" },
-    { name = "flask-caching", specifier = ">=2.0.2,<3" },
+    { name = "flask-caching", specifier = ">=2.1.0,<3" },
     { name = "waitress", specifier = ">=3.0.2,<4" },
     { name = "web3", specifier = ">=7.15.0,<8" },
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -796,18 +796,19 @@ wheels = [
 
 [[package]]
 name = "flask"
-version = "2.3.3"
+version = "3.1.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "blinker" },
     { name = "click" },
     { name = "itsdangerous" },
     { name = "jinja2" },
+    { name = "markupsafe" },
     { name = "werkzeug" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/46/b7/4ace17e37abd9c21715dea5ee11774a25e404c486a7893fa18e764326ead/flask-2.3.3.tar.gz", hash = "sha256:09c347a92aa7ff4a8e7f3206795f30d826654baf38b873d0744cd571ca609efc", size = 672756, upload-time = "2023-08-21T19:52:35.012Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/26/00/35d85dcce6c57fdc871f3867d465d780f302a175ea360f62533f12b27e2b/flask-3.1.3.tar.gz", hash = "sha256:0ef0e52b8a9cd932855379197dd8f94047b359ca0a78695144304cb45f87c9eb", size = 759004, upload-time = "2026-02-19T05:00:57.678Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fd/56/26f0be8adc2b4257df20c1c4260ddd0aa396cf8e75d90ab2f7ff99bc34f9/flask-2.3.3-py3-none-any.whl", hash = "sha256:f69fcd559dc907ed196ab9df0e48471709175e696d6e698dd4dbe940f96ce66b", size = 96112, upload-time = "2023-08-21T19:52:33.115Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/9c/34f6962f9b9e9c71f6e5ed806e0d0ff03c9d1b0b2340088a0cf4bce09b18/flask-3.1.3-py3-none-any.whl", hash = "sha256:f4bcbefc124291925f1a26446da31a5178f9483862233b23c0c96a20701f670c", size = 103424, upload-time = "2026-02-19T05:00:56.027Z" },
 ]
 
 [[package]]
@@ -1455,7 +1456,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "flask", specifier = ">=2.3.2,<3" },
+    { name = "flask", specifier = ">=3.1.3,<4" },
     { name = "flask-caching", specifier = ">=2.0.2,<3" },
     { name = "waitress", specifier = ">=3.0.2,<4" },
     { name = "web3", specifier = ">=6.8.0,<7" },


### PR DESCRIPTION
Closes #13.

## What
Bumps `Flask` from `>=2.3.2,<3` to `>=3.1.3,<4` (resolves to 3.1.3) — first release patched against **CVE-2026-27205 / GHSA-68rp-wp8r-4726** (session does not add `Vary: Cookie` on some access forms). `flask-caching` stays on 2.x (2.3.1), which supports Flask 3.

## Why
The server uses no Flask sessions and serves only public market data, so this low-severity bug is not reachable here — the dependency is upgraded to clear the advisory and move onto a supported Flask major.

## Validation (run locally)
- `uv lock` regenerated; `flask` → 3.1.3, `flask-caching` → 2.3.1
- `uv run python -c "import server; server.create_app()"` — app builds OK under Flask 3
- `black --check` ✅ · `isort --check-only` ✅ · `mypy server.py` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)